### PR TITLE
Fixing seed method 

### DIFF
--- a/EmpleoDotNet/Migrations/Configuration.cs
+++ b/EmpleoDotNet/Migrations/Configuration.cs
@@ -28,6 +28,8 @@ namespace EmpleoDotNet.Migrations
                                               location);
             }
             #endregion
+            //This triggers the save to the database making entity framework assign the correct Id's to the locationsList
+            context.SaveChanges();
 
             #region JobOpportunities
 


### PR DESCRIPTION
Fixing seed method by saving the locations to the db before using them in the job opportunities.
The code was using temporary Ids for the locations, and this caused errors when running the seed method, the solution was to force Entity framework to save the locations before using them, and that made them have the correct Ids.