### PR TITLE
Fixing Add issue with the repositories

### DIFF
--- a/EmpleoDotNet/Models/Repositories/BaseRepository.cs
+++ b/EmpleoDotNet/Models/Repositories/BaseRepository.cs
@@ -11,7 +11,7 @@ namespace EmpleoDotNet.Models.Repositories
         public BaseRepository()
         {
             Context = new Models.Database();
-            
+            DbSet = Context.Set<T>();
         }
 
         public BaseRepository(DbContext context)

--- a/EmpleoDotNet/Models/Repositories/BaseRepository.cs
+++ b/EmpleoDotNet/Models/Repositories/BaseRepository.cs
@@ -11,12 +11,13 @@ namespace EmpleoDotNet.Models.Repositories
         public BaseRepository()
         {
             Context = new Models.Database();
-            DbSet = Context.Set<T>();
+            
         }
 
         public BaseRepository(DbContext context)
         {
             Context = context;
+            DbSet = Context.Set<T>();
         }
 
         protected T GetById(int? id)

--- a/EmpleoDotNet/Models/Repositories/JobOpportunityRepository.cs
+++ b/EmpleoDotNet/Models/Repositories/JobOpportunityRepository.cs
@@ -41,9 +41,9 @@ namespace EmpleoDotNet.Models.Repositories
                 .ToList();
         }
 
-        public JobOpportunityRepository(DbContext context)
+        public JobOpportunityRepository(DbContext context):base(context)
         {
-            this.Context = context;
+            
         }
     }
 }

--- a/EmpleoDotNet/Models/Repositories/LocationRepository.cs
+++ b/EmpleoDotNet/Models/Repositories/LocationRepository.cs
@@ -38,9 +38,9 @@ namespace EmpleoDotNet.Models.Repositories
             return location;
         }
 
-        public LocationRepository(DbContext context)
+        public LocationRepository(DbContext context):base(context)
         {
-            this.Context = context;
+            
         }
     }
 }

--- a/EmpleoDotNet/Models/Repositories/TagRepository.cs
+++ b/EmpleoDotNet/Models/Repositories/TagRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data.Entity;
 using System.Linq;
 using System.Web;
 
@@ -17,6 +18,11 @@ namespace EmpleoDotNet.Models.Repositories
         {
             var tag = GetAll().FirstOrDefault(a => a.Id == id);
             return tag;
+        }
+
+        public TagRepository(DbContext context):base(context)
+        {
+            
         }
     }
 }

--- a/EmpleoDotNet/Web.config
+++ b/EmpleoDotNet/Web.config
@@ -10,7 +10,7 @@
   </configSections>
   <connectionStrings>
     <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\v11.0;AttachDbFilename=|DataDirectory|\aspnet-EmpleoDotNet-20140527072351.mdf;Initial Catalog=aspnet-EmpleoDotNet-20140527072351;Integrated Security=True" providerName="System.Data.SqlClient" />
-    <add name="EmpleoDotNetConn" connectionString="Data Source=.\sqlexpress;Initial Catalog=EmpleoDotNet;Integrated Security=True" providerName="System.Data.SqlClient" />
+    <add name="EmpleoDotNetConn" connectionString="Data Source=(LocalDb)\v11.0;AttachDbFilename=|DataDirectory|\aspnet-EmpleoDotNet.mdf;Initial Catalog=aspnet-EmpleoDotNet;Integrated Security=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0" />

--- a/EmpleoDotNet/Web.config
+++ b/EmpleoDotNet/Web.config
@@ -10,7 +10,7 @@
   </configSections>
   <connectionStrings>
     <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\v11.0;AttachDbFilename=|DataDirectory|\aspnet-EmpleoDotNet-20140527072351.mdf;Initial Catalog=aspnet-EmpleoDotNet-20140527072351;Integrated Security=True" providerName="System.Data.SqlClient" />
-    <add name="EmpleoDotNetConn" connectionString="Data Source=(LocalDb)\v11.0;AttachDbFilename=|DataDirectory|\aspnet-EmpleoDotNet.mdf;Initial Catalog=aspnet-EmpleoDotNet;Integrated Security=True" providerName="System.Data.SqlClient" />
+    <add name="EmpleoDotNetConn" connectionString="Data Source=.\sqlexpress;Initial Catalog=EmpleoDotNet;Integrated Security=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0" />


### PR DESCRIPTION
The Base repository had the correct implementation to save the entities, because it sets up it's dbSet in the default constructor, the problem was that the derivated repositories didn't call that constructor nor set up the dbSet, so the repository didn't have the ability to save new entities.

I just added the dbSet setup to one of the baseRepository constructors, and call it from each of the derivated repositories.