### PR TITLE
Habilitar C# 6 en EmpleoDotNet

### DIFF
--- a/EmpleoDotNet/Controllers/AccountController.cs
+++ b/EmpleoDotNet/Controllers/AccountController.cs
@@ -160,10 +160,7 @@ namespace EmpleoDotNet.Controllers
             {
                 // User does not have a password so remove any validation errors caused by a missing OldPassword field
                 ModelState state = ModelState["OldPassword"];
-                if (state != null)
-                {
-                    state.Errors.Clear();
-                }
+                state?.Errors.Clear();
 
                 if (ModelState.IsValid)
                 {

--- a/EmpleoDotNet/Controllers/CreditsController.cs
+++ b/EmpleoDotNet/Controllers/CreditsController.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-using System.Web.Mvc;
+﻿using System.Web.Mvc;
 
 namespace EmpleoDotNet.Controllers
 {

--- a/EmpleoDotNet/EmpleoDotNet.csproj
+++ b/EmpleoDotNet/EmpleoDotNet.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.1\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.1\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -23,6 +25,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <UseGlobalApplicationHostFile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -60,6 +64,10 @@
     </Reference>
     <Reference Include="Glimpse.Mvc5, Version=1.5.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Glimpse.Mvc5.1.5.3\lib\net45\Glimpse.Mvc5.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.1\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
@@ -492,6 +500,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.1\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.1\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
   </Target>
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">

--- a/EmpleoDotNet/Models/EntityFrameworkUnitOfWork.cs
+++ b/EmpleoDotNet/Models/EntityFrameworkUnitOfWork.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data.Entity;
-using System.Linq;
-using System.Web;
+﻿using System.Data.Entity;
 
 namespace EmpleoDotNet.Models
 {

--- a/EmpleoDotNet/Models/Repositories/BaseRepository.cs
+++ b/EmpleoDotNet/Models/Repositories/BaseRepository.cs
@@ -10,7 +10,7 @@ namespace EmpleoDotNet.Models.Repositories
 
         public BaseRepository()
         {
-            Context = new Models.EmpleadoContext();
+            Context = new EmpleadoContext();
             DbSet = Context.Set<T>();
         }
 

--- a/EmpleoDotNet/Models/Repositories/ILocationRepository.cs
+++ b/EmpleoDotNet/Models/Repositories/ILocationRepository.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace EmpleoDotNet.Models.Repositories
 {

--- a/EmpleoDotNet/Models/Repositories/ITagRepository.cs
+++ b/EmpleoDotNet/Models/Repositories/ITagRepository.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace EmpleoDotNet.Models.Repositories
 {

--- a/EmpleoDotNet/Models/Repositories/TagRepository.cs
+++ b/EmpleoDotNet/Models/Repositories/TagRepository.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
-using System.Web;
 
 namespace EmpleoDotNet.Models.Repositories
 {

--- a/EmpleoDotNet/Models/TableConfigurations/BaseTableConfiguration.cs
+++ b/EmpleoDotNet/Models/TableConfigurations/BaseTableConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using System.Data.Entity.ModelConfiguration;
-using System.Runtime.InteropServices;
 
 namespace EmpleoDotNet.Models.TableConfigurations
 {
@@ -17,7 +16,7 @@ namespace EmpleoDotNet.Models.TableConfigurations
             Para mantener esta comodidad pero generar una DB apta para el mundo real 
             Cambiar Nombre de la columna.*/
             HasKey(x => x.Id);
-            Property(x => x.Id).HasColumnName(string.Format("{0}Id", typeof (T).Name)).HasDatabaseGeneratedOption(DatabaseGeneratedOption.Identity);
+            Property(x => x.Id).HasColumnName($"{typeof (T).Name}Id").HasDatabaseGeneratedOption(DatabaseGeneratedOption.Identity);
         }
     }
 }

--- a/EmpleoDotNet/Models/TableConfigurations/JobOpportunityTableConfiguration.cs
+++ b/EmpleoDotNet/Models/TableConfigurations/JobOpportunityTableConfiguration.cs
@@ -1,6 +1,4 @@
-﻿using System.Data.Entity.ModelConfiguration;
-
-namespace EmpleoDotNet.Models.TableConfigurations
+﻿namespace EmpleoDotNet.Models.TableConfigurations
 {
     /// <summary>
     /// Table configuration de la Tabla JobOpportunity

--- a/EmpleoDotNet/Models/Tag.cs
+++ b/EmpleoDotNet/Models/Tag.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Web;
 
 namespace EmpleoDotNet.Models
 {

--- a/EmpleoDotNet/Views/Home/Index.cshtml
+++ b/EmpleoDotNet/Views/Home/Index.cshtml
@@ -26,7 +26,7 @@
                 <div class="tint"></div>
                 <div class="slide-content">
                     <h2>Necesitas un colaborador?</h2>
-                    <p><a href="@Url.Action("New", "JobOpportunity")" class="btn btn-lg btn-default">Crea una Empleo</a>
+                    <p><a href="@Url.Action("New", "JobOpportunity")" class="btn btn-lg btn-default">Crea un Empleo</a>
                     </p>
                 </div>
             </div>

--- a/EmpleoDotNet/Views/Shared/_LastestJobs.cshtml
+++ b/EmpleoDotNet/Views/Shared/_LastestJobs.cshtml
@@ -1,5 +1,4 @@
-﻿
-@using EmpleoDotNet.Helpers
+﻿@using EmpleoDotNet.Helpers
 @model List<EmpleoDotNet.Models.JobOpportunity>
 
 <table class="table">
@@ -12,7 +11,7 @@
     @foreach (var job in Model)
     {
         <tr>
-            <td>@job.PublishedDate.Value.ToString("dd/mm/yyyy")</td>
+            <td>@(job.PublishedDate?.ToString("dd/mm/yyyy"))</td>
             <td>
                 <strong>@job.CompanyName</strong> |
                 <a href="@Url.RouteUrl(
@@ -27,8 +26,7 @@
                     </a>
                 </td>
                 <td>@job.Category.ToEnumDescription()</td>
-                <td>@(job.Location != null ? job.Location.Name : "")</td>
+                <td>@(job.Location?.Name ?? "")</td>
             </tr>
     }
 </table>
-

--- a/EmpleoDotNet/Web.config
+++ b/EmpleoDotNet/Web.config
@@ -81,4 +81,14 @@
       </ignoredTypes>
     </runtimePolicies>
   </glimpse>
+  <system.codedom>
+    <compilers>
+      <compiler language="c#;cs;csharp" extension=".cs"
+        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+        warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701"/>
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb"
+        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+        warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"/>
+    </compilers>
+  </system.codedom>
 </configuration>

--- a/EmpleoDotNet/packages.config
+++ b/EmpleoDotNet/packages.config
@@ -18,7 +18,9 @@
   <package id="Microsoft.Bcl" version="1.1.8" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.1" targetFramework="net45" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.0.0" targetFramework="net45" />
+  <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.Owin" version="2.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="2.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="2.0.0" targetFramework="net45" />


### PR DESCRIPTION
Para el código en C# no hubo que hacer nada. Simplemente cambié algunas cosas a C# 6 y compiló solo en VS 2015.

Para usarlo en Razor files hubo que descargar este nuget package: http://stackoverflow.com/a/30832849/2563028

Eso será un polyfill temporal hasta que migremos a ASP.NET 5 con MVC 6.

Aproveché e hice un poco de cleanup.