### PR TITLE
 Fixed Icono mal posicionado y Dar estilo al texto de la descripción del puesto

### DIFF
--- a/EmpleoDotNet/Content/css/theme/style.css
+++ b/EmpleoDotNet/Content/css/theme/style.css
@@ -932,6 +932,18 @@ header {
 			top: 0;
 		}
 
+    @media (max-width: 480px) {
+        .job-location:before, 
+        .candidate-location:before {
+            color: #14b1bb;
+            content: "\f041";
+            font-family: "FontAwesome";
+            left: 17px;
+            position: absolute;
+            top: 0;
+            margin-top: 47px;
+        }
+    }
 	.job-dates {
 		padding-left: 37px;
 		position: relative;

--- a/EmpleoDotNet/Controllers/JobOpportunityController.cs
+++ b/EmpleoDotNet/Controllers/JobOpportunityController.cs
@@ -58,8 +58,6 @@ namespace EmpleoDotNet.Controllers
 
             if (vm != null)
             {
-                vm.Description = JobOpportunityDescriptionBuilder.BuildDescription(vm.Description);
-
                 var relatedJobs =
                     _jobRepository.GetAllJobOpportunities()
                         .Where(
@@ -95,6 +93,7 @@ namespace EmpleoDotNet.Controllers
         }
 
         [HttpPost, ValidateAntiForgeryToken]
+        [ValidateInput(false)]
         public ActionResult New(NewJobOpportunityViewModel model)
         {
             if (!ModelState.IsValid)

--- a/EmpleoDotNet/Views/JobOpportunity/Detail.cshtml
+++ b/EmpleoDotNet/Views/JobOpportunity/Detail.cshtml
@@ -26,7 +26,9 @@
             <div class="col-sm-8">
                 <article>
                     <h2>Detalles del Puesto</h2>
-                    @Html.Raw(Model.Description)
+                    <article>
+                        @Html.Raw(Model.Description)
+                    </article>
                     <h3>Como aplicar</h3>
                     <p>Enviar CV <a href="mailto:@Model.CompanyEmail">@Model.CompanyEmail</a> </p>
                 </article>

--- a/EmpleoDotNet/Views/JobOpportunity/New.cshtml
+++ b/EmpleoDotNet/Views/JobOpportunity/New.cshtml
@@ -78,7 +78,7 @@
                 <div class="col-sm-12">
                     <div class="form-group" id="job-description-group">
                         <h2>Descripcion del Puesto</h2>
-                        @Html.TextAreaFor(m => m.Description, new {@class = "form-control"})
+                        @Html.TextAreaFor(m => m.Description, new {@class = "form-control textarea" })
                         @Html.ValidationMessageFor(m => m.Description)
                     </div>
                 </div>

--- a/EmpleoDotNet/Web.config
+++ b/EmpleoDotNet/Web.config
@@ -23,7 +23,7 @@
   <system.web>
     <authentication mode="None" />
     <compilation debug="true" targetFramework="4.5" />
-    <httpRuntime targetFramework="4.5" />
+    <httpRuntime targetFramework="4.5" requestValidationMode="2.0"/>
     <!-- Glimpse: This can be commented in to add additional data to the Trace tab when using WebForms
         <trace writeToDiagnosticsTrace="true" enabled="true" pageOutput="false"/> -->
     <httpModules>


### PR DESCRIPTION
### What's New

- Fixed #142 Icono mal posicionado en la vista movil

<img width="1440" alt="screen shot 2016-01-11 at 5 24 16 pm" src="https://cloud.githubusercontent.com/assets/6517152/12247039/6fefb7fc-b888-11e5-90a1-bddcacceb1a7.png">

**Relacionado al issue #124, claro, no el release final**
- Poder dar estilo a la descripcion del mensaje
- Removida dependencia del helper JobOpportunityDescriptionBuilder
- Agregado atributo ValidateInput(false) en metodo del New del JobOpportunityController

**Input**
<img width="1440" alt="screen shot 2016-01-11 at 5 53 45 pm" src="https://cloud.githubusercontent.com/assets/6517152/12247877/658c2d3c-b88c-11e5-821b-0e3294142ebd.png">

**Detail**
<img width="1440" alt="screen shot 2016-01-11 at 5 53 54 pm" src="https://cloud.githubusercontent.com/assets/6517152/12247868/57716e7e-b88c-11e5-9167-d2c3f47a35e8.png">
