### PR TITLE
Quita la validación del cambio de color de los íconos del menú

### DIFF
--- a/EmpleoDotNet/Scripts/app.js
+++ b/EmpleoDotNet/Scripts/app.js
@@ -8,17 +8,11 @@
 
 // Changes the menu icons color when background is hidden
 
-if (!isHomePage()) {
-    $(window).scroll(function () {
-        var scroll = $(window).scrollTop();
-        if (scroll > 50) {
-            $("header > .container a").css("color", "#fff");
-        } else {
-            $("header > .container a").css("color", "#14b1bb");
-        }
-    });
-}
-
-function isHomePage() {
-    return window.location.pathname === "/";
-}
+$(window).scroll(function () {
+    var scroll = $(window).scrollTop();
+    if (scroll > 50) {
+        $("header > .container a").css("color", "#fff");
+    } else {
+        $("header > .container a").css("color", "#14b1bb");
+    }
+});


### PR DESCRIPTION
Como anteriormente se tenia una un banner de portada en el home page había un validación para cambiarle el color a los íconos del menú siempre y cuando no se estuviese en el home, pero como ya se quitó dicho banner esta validación ya no es necesaria.

#201

![2016-01-23 07_19_08-- emplea do](https://cloud.githubusercontent.com/assets/5460365/12529912/bba4a53c-c1a1-11e5-9f9d-a656f30a99fa.png)

![2016-01-23 07_20_46-- emplea do](https://cloud.githubusercontent.com/assets/5460365/12529918/fa734da4-c1a1-11e5-9621-fb554fa564cd.png)

