### PR TITLE
Header siempre visible

### DIFF
--- a/EmpleoDotNet/Scripts/app.js
+++ b/EmpleoDotNet/Scripts/app.js
@@ -4,15 +4,3 @@
         window.location = detailUrl;
     }
 };
-
-
-// Changes the menu icons color when background is hidden
-
-$(window).scroll(function () {
-    var scroll = $(window).scrollTop();
-    if (scroll > 50) {
-        $("header > .container a").css("color", "#fff");
-    } else {
-        $("header > .container a").css("color", "#14b1bb");
-    }
-});

--- a/EmpleoDotNet/Scripts/theme/settings.js
+++ b/EmpleoDotNet/Scripts/theme/settings.js
@@ -9,19 +9,6 @@
 
         // ====================================================================
 
-        // Header scroll function
-
-        $(window).scroll(function() {    
-        	var scroll = $(window).scrollTop();
-        	if (scroll > 50) {
-        	    $("#header-background").slideDown(300);
-        	} else {
-        	    $("#header-background").slideUp(300);
-        	}
-        });
-
-        // ====================================================================
-
         // Flex Menu
 
         $('.menu').flexMenu({


### PR DESCRIPTION
Se removio el codigo para que a pesar de que se haga scroll en la pagina siempre se muestre el header (no se vuelva transparente) segun el issue #203

Antes
![capture 1](https://cloud.githubusercontent.com/assets/4156062/12539601/3f79cc08-c2cd-11e5-9b97-b58c4cf37420.PNG)


Ahora
![capture](https://cloud.githubusercontent.com/assets/4156062/12539606/58c1cefe-c2cd-11e5-9f18-611bc4a2fda9.PNG)

