### PR TITLE
Arreglando falta ortográfica verbo haber modo imperativo y pronombre tú

### DIFF
--- a/EmpleoDotNet/Views/Credits/Index.cshtml
+++ b/EmpleoDotNet/Views/Credits/Index.cshtml
@@ -4,8 +4,8 @@
 <section id="contributors">
     <div class="container">
         <div class="row text-center" id="contributorsList">
-            <h3>Traído a ustedes gracias a las contribuciones de personas como tu</h3>
-            <p>Tú también puedes contribuir, toma <a href="https://github.com/developersdo/empleo-dot-net/issues">un issue en github</a> y has un pull request</p>
+            <h3>Traído a ustedes gracias a las contribuciones de personas como tú</h3>
+            <p>Tú también puedes contribuir, toma <a href="https://github.com/developersdo/empleo-dot-net/issues">un issue en github</a> y haz un pull request</p>
         </div>
 
         @section scripts


### PR DESCRIPTION
El pronombre **_tú_** lleva acento, en una oración no lo tenía.

La forma correcta de escribir el verbo haber en modo imperativo es **HAZ**. Actualmente dice _has un pull request_ . **_Has_** corresponde a la segunda persona singular del modo indicativo , tiempo presente del verbo haber, ejemplo : "Tú has cambiado mucho"