### PR TITLE
Fixed broken link pointing to the new job opportunity wizard.

### DIFF
--- a/EmpleoDotNet/Views/JobOpportunity/New.cshtml
+++ b/EmpleoDotNet/Views/JobOpportunity/New.cshtml
@@ -20,7 +20,7 @@
     <div class="row text-center">
         <div class="col-sm-12">
             <div class="alert alert-info" role="alert">
-                Prueba nuestro nuevo proceso gu&iacute;ado de creaci&oacute;n de posiciones haciendo <a href="@Url.Action(" Wizard")" class="alert-link">click aqu&iacute;</a>
+                Prueba nuestro nuevo proceso gu&iacute;ado de creaci&oacute;n de posiciones haciendo <a href="@Url.Action("Wizard")" class="alert-link">click aqu&iacute;</a>
             </div>
             <div class="jumbotron">
                 <h1>Crea un empleo</h1>


### PR DESCRIPTION
The link was located in http://localhost:18661/JobOpportunity/New and contained and unnecessary space causing a 404 error page to appear.