### PR TITLE
Establecer codificación global como UTF-8

### DIFF
--- a/EmpleoDotNet/Web.config
+++ b/EmpleoDotNet/Web.config
@@ -50,6 +50,13 @@
     <httpHandlers>
       <add path="glimpse.axd" verb="GET" type="Glimpse.AspNet.HttpHandler, Glimpse.AspNet" />
     </httpHandlers>
+    <globalization
+      fileEncoding="utf-8" 
+      requestEncoding="utf-8" 
+      responseEncoding="utf-8"
+      culture="en-US"
+      uiCulture="de-DE"
+    />
   </system.web>
   <system.webServer>
     <modules>

--- a/EmpleoDotNet/Web.config
+++ b/EmpleoDotNet/Web.config
@@ -54,8 +54,6 @@
       fileEncoding="utf-8" 
       requestEncoding="utf-8" 
       responseEncoding="utf-8"
-      culture="en-US"
-      uiCulture="de-DE"
     />
   </system.web>
   <system.webServer>


### PR DESCRIPTION
Para evitar problemas de este tipo: 
![uf8 problems](https://cloud.githubusercontent.com/assets/3673104/13322279/21bcede4-dbaa-11e5-939d-637ccb2aa1ae.PNG)

No tengo nada instalado para probar este cambio, ¿alguien puede probar este cambio y confirmar que funciona?
