### PR TITLE
Match the web theme version on mobile

### DIFF
--- a/Mobile/Android/Resources/values/themes.xml
+++ b/Mobile/Android/Resources/values/themes.xml
@@ -3,9 +3,9 @@
 
     <style name="LandingPageTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:windowBackground">@color/background_window</item>
-        <item name="colorPrimary">@color/green</item>
-        <item name="colorPrimaryDark">@color/greenDark</item>
-        <item name="colorAccent">@color/banana</item>
+        <item name="colorPrimary">#14b1bb</item>
+        <item name="colorPrimaryDark">#10868F</item>
+        <item name="android:colorAccent">#14b1bb</item>
         <item name="android:textColorPrimary">@android:color/white</item>
         <item name="pstsIndicatorColor">#FFF</item>
         <item name="pstsShouldExpand">true</item>
@@ -14,10 +14,11 @@
 
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
     	<item name="android:windowBackground">@color/background_window</item>
-    	<item name="colorPrimary">#BC494E</item>
-        <item name="colorPrimaryDark">#8A363A</item>
+    	<item name="colorPrimary">#14b1bb</item>
+        <item name="colorPrimaryDark">#10868F</item>
+        <item name="android:colorAccent">#0C6469</item>
         <item name="android:editTextColor">@android:color/black</item>
-        <item name="colorAccent">#BC494E</item>
+        <item name="colorAccent">#0C6469</item>
         <item name="android:textColorPrimary">@android:color/white</item>
         <item name="android:textColorHint">#000</item>
         <item name="searchHintIcon">@null</item>


### PR DESCRIPTION
### This issue is related to #338 

# What's new

- Now the mobile app theme is matching the web version theme.

![screen shot 2016-03-22 at 14 06 09](https://cloud.githubusercontent.com/assets/5881238/13964344/44005aac-f037-11e5-9899-5576aa660285.png)
