### PR TITLE
Remove paddin-bottom

### DIFF
--- a/EmpleoDotNet/Content/Site.css
+++ b/EmpleoDotNet/Content/Site.css
@@ -1,6 +1,5 @@
 body {
     padding-top: 50px;
-    padding-bottom: 20px;
 }
 
 .padding-top-80{

--- a/EmpleoDotNet/Content/Site.less
+++ b/EmpleoDotNet/Content/Site.less
@@ -8,7 +8,6 @@
 /*General Rules*/
 body {
     padding-top: 50px;
-    padding-bottom: 20px;
 }
 
 input,select,textarea {


### PR DESCRIPTION
De acuerdo con el Issue #353 

El problema del padding-bottom causaba esto:

![capture](https://cloud.githubusercontent.com/assets/12973165/14029751/5342c686-f1da-11e5-826d-2ebb68ba7889.PNG)

En este pull request se corrige tomando la forma siguiente:

![capture2](https://cloud.githubusercontent.com/assets/12973165/14029768/653d0216-f1da-11e5-9ae2-275c9dde45da.PNG)
