### PR TITLE
Create transition between mainpage to filter search

### DIFF
--- a/Mobile/Android/Android.csproj
+++ b/Mobile/Android/Android.csproj
@@ -111,6 +111,8 @@
     <Compile Include="MainPage\BackPressImpl.cs" />
     <Compile Include="MainPage\JobsFragmentViewModel.cs" />
     <Compile Include="MainPage\FavoritesViewModel.cs" />
+    <Compile Include="MainPage\MainPageFragment.cs" />
+    <Compile Include="MainPage\MainPageFragmentViewModel.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />
@@ -170,6 +172,7 @@
     <AndroidResource Include="Resources\values\attr.xml" />
     <AndroidResource Include="Resources\layout\HomePageViewPagerLayout.axml" />
     <AndroidResource Include="Resources\transition\job_list_to_detail.axml" />
+    <AndroidResource Include="Resources\layout\MainPageFragmentLayout.axml" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\values\Strings.xml" />

--- a/Mobile/Android/Empleado.cs
+++ b/Mobile/Android/Empleado.cs
@@ -7,6 +7,8 @@ namespace Android
 		public static readonly string LandingPage = "LandingPage";
 
 		public static readonly string MainPage = "MainPage";
+
+		public static readonly string FilterLocationScreen = "FilterLocationScreen";
 	}
 }
 

--- a/Mobile/Android/Framework/Bootstrapping/Bootstrapping.cs
+++ b/Mobile/Android/Framework/Bootstrapping/Bootstrapping.cs
@@ -31,6 +31,8 @@ namespace Empleado
 
 				nav.Configure(ScreenName.MainPage, typeof(MainPageActivity));
 
+				nav.Configure(ScreenName.FilterLocationScreen, typeof(SearchActivity));
+
 				SimpleIoc.Default.Register<INavigationService>(() => nav);
 			}
 		}
@@ -53,6 +55,7 @@ namespace Empleado
 			SimpleIoc.Default.Register<SplashViewModel,SplashViewModel>();
 			SimpleIoc.Default.Register<JobsFragmentViewModel,JobsFragmentViewModel>();
 			SimpleIoc.Default.Register<FavoritesViewModel,FavoritesViewModel>();
+			SimpleIoc.Default.Register<MainPageFragmentViewModel,MainPageFragmentViewModel>();
 		}
 	}
 }

--- a/Mobile/Android/MainPage/MainPageActivity.cs
+++ b/Mobile/Android/MainPage/MainPageActivity.cs
@@ -16,16 +16,12 @@ using Android.Graphics;
 
 namespace Android.Activities
 {
-	[Activity (Theme="@style/AppTheme")]
+	[Activity (Theme="@style/AppTheme", Label="@string/MainPage")]
 	public class MainPageActivity : AppCompatActivityBase
 	{
-		ViewPagerFragment _viewPagerFragment;
+		MainPageFragment _viewPagerFragment;
 
 		V7Toolbar _toolBar;
-
-		SearchView _searchView;
-
-		View _searchLayout;
 
 		protected override void OnCreate (Bundle savedInstanceState)
 		{
@@ -37,55 +33,12 @@ namespace Android.Activities
 
 			SetViewReferences();
 
-			SetUpScreen ();
-		}
-
-		void SetUpScreen()
-		{
-			Title = GetString(Resource.String.MainPage);
-
 			SetSupportActionBar(_toolBar);
-
-			_searchLayout.Click += OnSearchLayoutSelected;
-
-			_searchView.QueryTextSubmit += OnQueryTextSubmit;
-
-			_searchView.SetIconifiedByDefault(false);
-
-			_searchView.SetQueryHint(GetString(Resource.String.HomePageSearchBarHint));
-
-			PersonalizeSearchView();
-		}
-
-		void PersonalizeSearchView ()
-		{
-			var ll = (LinearLayout)_searchView.GetChildAt(0);  
-
-			var ll2 = (LinearLayout)ll.GetChildAt(2);  
-
-			var ll3 = (LinearLayout)ll2.GetChildAt(1);  
-
-			var p = (EditText)ll3.GetChildAt(0);
-
-			p.SetHintTextColor(Color.LightGray);
-		}
-
-		void OnSearchLayoutSelected(object sender, EventArgs e)
-		{
-			_searchView.RequestFocus();
-		}
-
-		void OnQueryTextSubmit(object sender, SearchView.QueryTextSubmitEventArgs e){
-			
 		}
 
 		void SetViewReferences ()
 		{
-			_toolBar = FindViewById<V7Toolbar>(Resource.Id.MainToolbar);
-
-			_searchView = FindViewById<SearchView> (Resource.Id.MainSearchView);
-
-			_searchLayout = FindViewById (Resource.Id.MainSearchLayout);
+			_toolBar = FindViewById<V7Toolbar> (Resource.Id.MainToolbar);
 		}
 
 		void Init (Bundle savedInstanceState)
@@ -96,25 +49,23 @@ namespace Android.Activities
 
 			} else {
 				
-				_viewPagerFragment = (ViewPagerFragment) SupportFragmentManager.Fragments[0];
+				_viewPagerFragment = (MainPageFragment) SupportFragmentManager.Fragments[0];
 			}
 		}
 
 		void SetupInnerFragment ()
 		{
-			_viewPagerFragment = new ViewPagerFragment();
+			_viewPagerFragment = new MainPageFragment();
 
 			SupportFragmentManager
 				.BeginTransaction()
-				.Replace(Resource.Id.container, _viewPagerFragment)
+				.Replace(Resource.Id.parent_container, _viewPagerFragment)
 				.Commit();
 		}
 
 		public override void OnBackPressed ()
 		{
-			if (!_viewPagerFragment.OnBackPressed()) {
-				base.OnBackPressed();
-			}
+			_viewPagerFragment.OnBackPressed();
 		}
 	}
 }

--- a/Mobile/Android/MainPage/MainPageFragment.cs
+++ b/Mobile/Android/MainPage/MainPageFragment.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Util;
+using Android.Views;
+using Android.Widget;
+using Android.Graphics;
+using Android.Support.V4.App;
+using Android.App;
+using GalaSoft.MvvmLight.Helpers;
+using Microsoft.Practices.ServiceLocation;
+
+namespace Android
+{
+	public class MainPageFragment : Android.Support.V4.App.Fragment
+	{
+		View _searchLayout;
+
+		SearchView _searchView;
+
+		LinearLayout _locationContainer;
+
+		ViewPagerFragment _viewPagerFragment;
+
+		MainPageFragmentViewModel _viewModel;
+
+		public override void OnCreate (Bundle savedInstanceState)
+		{
+			base.OnCreate (savedInstanceState);
+
+			GetServices();
+
+			Init();
+		}
+
+		void GetServices ()
+		{
+			_viewModel = ServiceLocator.Current.GetInstance<MainPageFragmentViewModel>();
+		}
+
+		void Init ()
+		{
+			_viewPagerFragment = new ViewPagerFragment();
+
+			ChildFragmentManager
+				.BeginTransaction()
+				.Replace(Resource.Id.container, _viewPagerFragment)
+				.Commit();
+		}
+
+		void SetUpScreen()
+		{
+			_searchLayout.Click += OnSearchLayoutSelected;
+
+			_searchView.QueryTextSubmit += OnQueryTextSubmit;
+
+			_searchView.SetIconifiedByDefault(false);
+
+			_searchView.SetQueryHint(GetString(Resource.String.HomePageSearchBarHint));
+
+			PersonalizeSearchView();
+		}
+
+		public override void OnActivityCreated (Bundle savedInstanceState)
+		{
+			base.OnActivityCreated (savedInstanceState);
+
+			SetUpScreen();
+		}
+
+		void PersonalizeSearchView ()
+		{
+			var ll = (LinearLayout)_searchView.GetChildAt(0);  
+
+			var ll2 = (LinearLayout)ll.GetChildAt(2);  
+
+			var ll3 = (LinearLayout)ll2.GetChildAt(1);  
+
+			var p = (EditText)ll3.GetChildAt(0);
+
+			p.SetHintTextColor(Color.LightGray);
+		}
+
+		void SetBindings ()
+		{
+			_locationContainer.SetCommand("Click", _viewModel.NavigateToFilterScreenCommand);
+		}
+
+		public override void OnViewCreated (View view, Bundle savedInstanceState)
+		{
+			base.OnViewCreated (view, savedInstanceState);
+
+			SetBindings();
+		}
+
+		void OnSearchLayoutSelected(object sender, EventArgs e)
+		{
+			_searchView.RequestFocus();
+		}
+
+		void OnQueryTextSubmit(object sender, SearchView.QueryTextSubmitEventArgs e){
+
+		}
+
+		public override View OnCreateView (LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+		{
+			var view = inflater.Inflate(Resource.Layout.MainPageFragmentLayout, container, false);
+
+			_searchLayout = view.FindViewById (Resource.Id.MainSearchLayout);
+
+			_locationContainer = view.FindViewById<LinearLayout> (Resource.Id.locationContainer);
+
+			_searchView = view.FindViewById<SearchView> (Resource.Id.MainSearchView);
+
+			return view;
+		}
+
+		public bool OnBackPressed ()
+		{
+			return _viewPagerFragment.OnBackPressed();
+		}
+	}
+}
+

--- a/Mobile/Android/MainPage/MainPageFragmentViewModel.cs
+++ b/Mobile/Android/MainPage/MainPageFragmentViewModel.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using GalaSoft.MvvmLight.Command;
+using GalaSoft.MvvmLight.Views;
+using Microsoft.Practices.ServiceLocation;
+using GalaSoft.MvvmLight.Ioc;
+
+namespace Android
+{
+	public class MainPageFragmentViewModel : ViewModelBase
+	{
+		public RelayCommand NavigateToFilterScreenCommand { get; set; }
+
+		INavigationService _navigationService;
+
+		[PreferredConstructor]
+		public MainPageFragmentViewModel () : this(ServiceLocator.Current.GetInstance<INavigationService>())
+		{
+			
+		}
+
+		public MainPageFragmentViewModel (INavigationService navigationService)
+		{
+			_navigationService = navigationService;
+
+			NavigateToFilterScreenCommand = new RelayCommand(OnNavigateToFilterScreen);
+		}
+
+		void OnNavigateToFilterScreen ()
+		{
+			_navigationService.NavigateTo(ScreenName.FilterLocationScreen);
+		}
+	}
+}
+

--- a/Mobile/Android/Resources/layout/MainPageFragmentLayout.axml
+++ b/Mobile/Android/Resources/layout/MainPageFragmentLayout.axml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/MainSearchLayout"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:contextClickable="true">
+    <android.support.v7.widget.CardView
+        android:id="@+id/card_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:cardCornerRadius="4dp"
+        android:layout_margin="5dp">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:weightSum="1"
+            android:layout_height="wrap_content">
+            <SearchView
+                android:id="@+id/MainSearchView"
+                android:layout_width="0dp"
+                android:layout_weight="0.80"
+                android:layout_height="50dp" />
+            <LinearLayout
+                android:id="@+id/locationContainer"
+                android:layout_height="50dp"
+                android:background="#f0f0f0"
+                android:layout_width="0dp"
+                android:layout_weight="0.20">
+                <ImageView
+                    android:id="@+id/locationIcon"
+                    android:layout_width="0dp"
+                    android:layout_weight="0.30"
+                    android:clickable="true"
+                    android:alpha="0.6"
+                    android:layout_gravity="center_horizontal|center_vertical"
+                    android:src="@drawable/ic_near_me_black_48dp"
+                    android:layout_height="26dp" />
+            </LinearLayout>
+        </LinearLayout>
+    </android.support.v7.widget.CardView>
+    <ImageView
+        android:id="@+id/MainSearchLocationImage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="right" />
+    <FrameLayout
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/Mobile/Android/Resources/layout/MainPageLayout.axml
+++ b/Mobile/Android/Resources/layout/MainPageLayout.axml
@@ -2,52 +2,17 @@
 <android.support.design.widget.AppBarLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_height="wrap_content"
+    android:id="@+id/appbarlayout"
     android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
     <android.support.v7.widget.Toolbar
         android:id="@+id/MainToolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary" />
-    <LinearLayout
-        android:id="@+id/MainSearchLayout"
-        android:orientation="vertical"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:contextClickable="true">
-        <android.support.v7.widget.CardView
-            android:id="@+id/card_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:cardCornerRadius="4dp"
-            android:layout_margin="5dp">
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:weightSum="1"
-                android:layout_height="wrap_content">
-                <SearchView
-                    android:id="@+id/MainSearchView"
-                    android:layout_width="0dp"
-                    android:layout_weight="0.70"
-                    android:layout_height="50dp" />
-                <ImageView
-                    android:id="@+id/locationIcon"
-                    android:layout_width="0dp"
-                    android:layout_weight="0.30"
-                    android:alpha="0.6"
-                    android:layout_gravity="center_horizontal|center_vertical"
-                    android:src="@drawable/ic_near_me_black_48dp"
-                    android:layout_height="26dp" />
-            </LinearLayout>
-        </android.support.v7.widget.CardView>
-        <ImageView
-            android:id="@+id/MainSearchLocationImage"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="right" />
-        <FrameLayout
-            android:id="@+id/container"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
-    </LinearLayout>
+    <FrameLayout
+        android:layout_width="fill_parent"
+        android:id="@+id/parent_container"
+        android:layout_height="fill_parent"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
 </android.support.design.widget.AppBarLayout>

--- a/Mobile/Android/Resources/layout/SearchActivityLayout.axml
+++ b/Mobile/Android/Resources/layout/SearchActivityLayout.axml
@@ -22,6 +22,7 @@
             app:cardCornerRadius="4dp"
             android:layout_margin="5dp">
             <LinearLayout
+                android:id="@+id/MainSearchViewParent"
                 android:orientation="horizontal"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">

--- a/Mobile/Android/Resources/values/Strings.xml
+++ b/Mobile/Android/Resources/values/Strings.xml
@@ -17,5 +17,5 @@
     <string name="MainPage">Emplea.do</string>
     <string name="HomePageSearchBarHint">Busca empleo aquí</string>
     <string name="SearchPageSearchBarHint">Busca una dirección aquí</string>
-    <string name="SearchActivityTitle">Filtrar busqueda</string>
+    <string name="SearchActivityTitle">Filtrar búsqueda</string>
 </resources>

--- a/Mobile/Android/Resources/values/themes.xml
+++ b/Mobile/Android/Resources/values/themes.xml
@@ -9,7 +9,6 @@
         <item name="pstsUnderlineColor">#FFF</item>
     </style>
 
-
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
     	<item name="android:windowBackground">@color/background_window</item>
     	<item name="colorPrimary">#14b1bb</item>
@@ -20,6 +19,12 @@
         <item name="android:textColorPrimary">@android:color/white</item>
         <item name="android:textColorHint">#000</item>
         <item name="searchHintIcon">@null</item>
+        <item name="searchViewStyle">@style/SearchViewMy</item>
     </style>
+
+	<style name="SearchViewMy" parent="Widget.AppCompat.Light.SearchView">
+	    <item name="android:submitBackground">@null</item>
+	    <item name="android:queryBackground">@null</item>
+	</style>
 
 </resources>

--- a/Mobile/Android/SearchPage/SearchActivity.cs
+++ b/Mobile/Android/SearchPage/SearchActivity.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Android.App;
 using Android.Content;
 using Android.OS;
 using Android.Runtime;
@@ -11,18 +10,22 @@ using Android.Widget;
 using Android.Support.V7.App;
 using Android.Support.Design.Widget;
 using Android.Support.V4.View;
+using V7Toolbar = Android.Support.V7.Widget.Toolbar;
 using Android.Graphics;
+using Android.Support.V4.App;
+using Android.App;
+using Android.Activities;
 
 namespace Android
 {
-	[Activity (Label = "@string/SearchActivityTitle",Theme="@style/AppTheme")]
-	public class SearchActivity : AppCompatActivity
+	[Activity (Theme="@style/AppTheme", Label = "@string/SearchActivityTitle",ParentActivity = typeof(MainPageActivity))]
+	public class SearchActivity : AppCompatActivityBase
 	{
-		Android.Support.V7.Widget.Toolbar _toolBar;
+		V7Toolbar _toolBar;
 
 		SearchView _searchView;
 
-		View _searchLayout;
+		ViewGroup _searchLayout;
 
 		ListView _listView;
 
@@ -30,31 +33,31 @@ namespace Android
 		{
 			base.OnCreate (savedInstanceState);
 
-			SetContentView (Resource.Layout.SearchActivityLayout);
+			SetContentView(Resource.Layout.SearchActivityLayout);
 
-			SetViewReferences();
+			GetViewReferences();
 
-			SetUpScreen ();
+			SetupScreen();
 		}
 
-		void SetViewReferences ()
+		void GetViewReferences ()
 		{
 			_searchView = FindViewById<SearchView> (Resource.Id.MainSearchView);
 
-			_searchLayout = FindViewById (Resource.Id.MainSearchLayout);
+			_searchLayout = FindViewById<ViewGroup>(Resource.Id.MainSearchViewParent);
 
-			_toolBar = FindViewById<Android.Support.V7.Widget.Toolbar>(Resource.Id.MainToolbar);
+			_toolBar = FindViewById<V7Toolbar>(Resource.Id.MainToolbar);
 
 			_listView = FindViewById<ListView>(Resource.Id.resultList);
-
-			_listView.Adapter = new SearchLocationAdapter(this);
 		}
 
-		void SetUpScreen()
+		public void SetupScreen()
 		{
 			SetSupportActionBar(_toolBar);
 
-			Title = GetString(Resource.String.MainPage);
+			SupportActionBar.SetDisplayHomeAsUpEnabled(true);
+
+			_listView.Adapter = new SearchLocationAdapter(this);
 
 			_searchLayout.Click += OnSearchLayoutSelected;
 
@@ -65,6 +68,7 @@ namespace Android
 			_searchView.SetQueryHint(GetString(Resource.String.SearchPageSearchBarHint));
 
 			PersonalizeSearchView();
+
 		}
 
 		void OnQueryTextSubmit (object sender, SearchView.QueryTextSubmitEventArgs e)


### PR DESCRIPTION
This issue is related to #362 

# What's New

- Now when you click on the right arrow from main page it takes you to the search filter location.

![screen shot 2016-03-25 at 13 40 06](https://cloud.githubusercontent.com/assets/5881238/14051199/1d0fd2f6-f28f-11e5-9db3-64cb5e0f7139.png)

![screen shot 2016-03-25 at 13 42 50](https://cloud.githubusercontent.com/assets/5881238/14051253/8181816c-f28f-11e5-95ee-256a9e858a5e.png)


I made the filter location an Activity because the way the SearchView is positioned on the screen make it really difficult to navigate between fragment.