### PR TITLE
Main page search bar by context from now on

### DIFF
--- a/Mobile/Android/Android.csproj
+++ b/Mobile/Android/Android.csproj
@@ -122,6 +122,8 @@
     <Compile Include="MainPage\ViewPagerFragmentViewModel.cs" />
     <Compile Include="MainPage\SwipeToTabEventHandler.cs" />
     <Compile Include="MainPage\Tab.cs" />
+    <Compile Include="MainPage\NotifyJobListUserChangedQuery.cs" />
+    <Compile Include="MainPage\NotifyFavoriteListUserChangedQuery.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/Mobile/Android/MainPage/FavoritesFragment.cs
+++ b/Mobile/Android/MainPage/FavoritesFragment.cs
@@ -21,15 +21,35 @@ namespace Android
 	{
 		ListView _listView;
 
-		FavoritesViewModel _viewModel;
+		public FavoritesViewModel _viewModel { get; set; }
+
+		ProgressBar _loading;
+
+		View _queryNotFound;
+
+		List<Binding<bool, ViewStates>> binding;
 
 		public override void OnCreate (Bundle savedInstanceState)
 		{
 			base.OnCreate (savedInstanceState);
 
+			InitStuff();
+
 			GetDependencies();
 
 			_viewModel.OnCreate();
+		}
+
+		void InitStuff ()
+		{
+			binding = new List<Binding<bool, ViewStates>>();
+		}
+
+		void SetUpBindings ()
+		{
+			binding.Add(this.SetBinding (() => _viewModel.IsLoading, _loading, () => _loading.Visibility, BindingMode.OneWay).ConvertSourceToTarget(Converters.BoolToVisibilityReverseConverter));
+
+			binding.Add(this.SetBinding (() => _viewModel.QueryNotFound, _queryNotFound, () => _queryNotFound.Visibility, BindingMode.OneWay).ConvertSourceToTarget(Converters.BoolToVisibilityReverseConverter));
 		}
 
 		void GetDependencies ()
@@ -43,12 +63,18 @@ namespace Android
 
 			_listView = view.FindViewById<ListView> (Resource.Id.JobsListView);
 
+			_loading =  view.FindViewById<ProgressBar>(Resource.Id.loading);
+
+			_queryNotFound = view.FindViewById<View>(Resource.Id.contentNotFound);
+
 			return view;
 		}
 
 		public override void OnActivityCreated (Bundle savedInstanceState)
 		{
 			base.OnActivityCreated (savedInstanceState);
+
+			SetUpBindings();
 
 			SetUp ();
 		}
@@ -77,7 +103,7 @@ namespace Android
 
 		void SetUp()
 		{
-			_listView.Adapter = _viewModel.People.GetAdapter(OnJobAdapterView);
+			_listView.Adapter = _viewModel.Jobs.GetAdapter(OnJobAdapterView);
 		}
 
 		void OnListViewItemClick (object sender, AdapterView.ItemClickEventArgs e)

--- a/Mobile/Android/MainPage/JobsFragmentViewModel.cs
+++ b/Mobile/Android/MainPage/JobsFragmentViewModel.cs
@@ -46,7 +46,7 @@ namespace Android
 
 		void SubscribeToMessages ()
 		{
-			MessengerInstance.Register<NotifyUserChangedQuery>(this, OnUserSearch);
+			MessengerInstance.Register<NotifyJobListUserChangedQuery>(this, OnUserSearch);
 			MessengerInstance.Register<NotifyUserClearedText>(this, OnUserClearedText);
 		}
 
@@ -57,7 +57,7 @@ namespace Android
 			AddToJobs(_lastUpdatedJobs, true);
 		}
 
-		async void OnUserSearch(NotifyUserChangedQuery qr)
+		async void OnUserSearch(NotifyJobListUserChangedQuery qr)
 		{
 			var query = qr.Query;
 

--- a/Mobile/Android/MainPage/MainPageFragment.cs
+++ b/Mobile/Android/MainPage/MainPageFragment.cs
@@ -32,8 +32,6 @@ namespace Android
 
 		IMessenger _messenger;
 
-		ViewPager _viewPager;
-
 		public override void OnCreate (Bundle savedInstanceState)
 		{
 			base.OnCreate (savedInstanceState);
@@ -130,6 +128,8 @@ namespace Android
 		//So somehow i need to accomplish this task
 		void OnQuerySubmit(object sender, SearchView.QueryTextSubmitEventArgs e)
 		{
+
+
 			_viewModel.UserIsTypingCommand.Execute(_searchView.Query);
 		}
 

--- a/Mobile/Android/MainPage/MainPageFragmentViewModel.cs
+++ b/Mobile/Android/MainPage/MainPageFragmentViewModel.cs
@@ -21,7 +21,7 @@ namespace Android
 		[PreferredConstructor]
 		public MainPageFragmentViewModel () : this(ServiceLocator.Current.GetInstance<INavigationService>())
 		{
-			UserIsTypingCommand = new RelayCommand<string>(OnUserIsTyping);
+			UserIsTypingCommand = new RelayCommand<string>(OnUserSubmitText);
 
 			UserClearedTextCommand = new RelayCommand(OnUserClearedText);
 		}
@@ -38,7 +38,7 @@ namespace Android
 			MessengerInstance.Send<NotifyUserClearedText>(null);
 		}
 
-		void OnUserIsTyping (string parameter)
+		void OnUserSubmitText (string parameter)
 		{
 			MessengerInstance.Send<NotifyUserChangedQuery>(new NotifyUserChangedQuery
 				{

--- a/Mobile/Android/MainPage/NotifyFavoriteListUserChangedQuery.cs
+++ b/Mobile/Android/MainPage/NotifyFavoriteListUserChangedQuery.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Android
+{
+	public class NotifyFavoriteListUserChangedQuery
+	{
+		public string Query { get; set; }
+	}
+}
+

--- a/Mobile/Android/MainPage/NotifyJobListUserChangedQuery.cs
+++ b/Mobile/Android/MainPage/NotifyJobListUserChangedQuery.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Android
+{
+	public class NotifyJobListUserChangedQuery
+	{
+		public string Query { get; set; }
+	}
+}
+

--- a/Mobile/Android/MainPage/Tab.cs
+++ b/Mobile/Android/MainPage/Tab.cs
@@ -6,7 +6,7 @@ namespace Android
 	{
 		JobSearch,
 		Categories,
-		FavoriteCategories
+		Favorite
 	}
 }
 

--- a/Mobile/Android/MainPage/ViewPagerFragment.cs
+++ b/Mobile/Android/MainPage/ViewPagerFragment.cs
@@ -16,6 +16,7 @@ using Android.Activities;
 using Android.Support.V4.App;
 using Android.Content.Res;
 using Microsoft.Practices.ServiceLocation;
+using GalaSoft.MvvmLight.Helpers;
 
 namespace Android
 {
@@ -84,9 +85,16 @@ namespace Android
 		{
 			base.OnActivityCreated (savedInstanceState);
 
+			SetupViewPager();
+		}
+
+		void SetupViewPager ()
+		{
 			_adapter = new MainPagerAdapter (ChildFragmentManager, Resources);
 
 			_viewPager.Adapter = _adapter;
+
+			_viewPager.PageScrolled += OnPageScrolled;
 
 			_tabLayout.TabGravity = TabLayout.GravityFill;
 
@@ -103,6 +111,11 @@ namespace Android
 			}
 
 			return false;
+		}
+
+		void OnPageScrolled (object sender, ViewPager.PageScrolledEventArgs e)
+		{
+			_viewModel.PageScrolledCommand.Execute(e.Position);
 		}
 	}
 }

--- a/Mobile/Android/MainPage/ViewPagerFragmentViewModel.cs
+++ b/Mobile/Android/MainPage/ViewPagerFragmentViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using GalaSoft.MvvmLight;
+using GalaSoft.MvvmLight.Command;
 
 namespace Android
 {
@@ -7,14 +8,56 @@ namespace Android
 	{
 		public event EventHandler<SwipeToTabEventHandler> SwipeToTabEvent;
 
+		public int CurrentPage { get; set; }
+
+		public RelayCommand<int> PageScrolledCommand { get; set; }
+
 		public override void OnCreate ()
 		{
+			PageScrolledCommand = new RelayCommand<int>(OnPageScrolled);
+
 			SubscribeServices();
+		}
+
+		void OnPageScrolled (int position)
+		{
+			CurrentPage = position;
 		}
 
 		void SubscribeServices ()
 		{
 			MessengerInstance.Register<NotifySearchBarPutText>(this, OnSearchBarPutText);
+			MessengerInstance.Register<NotifyUserChangedQuery>(this, OnNotifyUserChangedQuery);
+		}
+
+		void OnNotifyUserChangedQuery (NotifyUserChangedQuery parameter)
+		{
+			var page = (Tab) CurrentPage;
+
+			switch(page)
+			{
+			case Tab.JobSearch:
+				{
+					SendMessageTo<NotifyJobListUserChangedQuery>(new NotifyJobListUserChangedQuery
+						{
+							Query = parameter.Query
+						});
+				}
+				break;
+			case Tab.Favorite:
+				{
+					SendMessageTo<NotifyFavoriteListUserChangedQuery>(new NotifyFavoriteListUserChangedQuery
+						{
+							Query = parameter.Query
+						});
+				}
+				break;
+			}
+		}
+
+		void SendMessageTo<T>(T arg)
+		{
+			MessengerInstance.Send<T>(arg);
 		}
 
 		void OnSearchBarPutText (NotifySearchBarPutText parameter)


### PR DESCRIPTION
### This issue is related to #374 

# What's New

Let's say you are looking for a job, if you type a query into the search bar, it should only refresh the job list since that's the tab you are right now.

If you are looking for saved jobs position (Favorites), and you type text into the search bar it should filter the saved jobs by title.

![mar 30 2016 15 28](https://cloud.githubusercontent.com/assets/5881238/14156429/04f6d47a-f68c-11e5-93be-0a47743b16cc.gif)
