### PR TITLE
Corrects duplicate in Strings.xml

### DIFF
--- a/Mobile/Android/Resources/values/Strings.xml
+++ b/Mobile/Android/Resources/values/Strings.xml
@@ -1,24 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="ApplicationName">Emplea.do</string>
-
     <string name="startApp">Iniciar</string>
-
     <string name="first_page_description">Encuentra empleos, envía CV, y más</string>
     <string name="first_page_title">Emplea.do Móvil</string>
-
     <string name="second_page_description">Encuentra el empleo de tus sueños</string>
     <string name="second_page_title">No más milla extra</string>
-
     <string name="third_page_description">Únete a la nueva moda de empleos remoto</string>
     <string name="third_page_title">Trabajos remoto</string>
-    <string name="ApplicationName">Android</string>
     <string name="IsRemote">Remoto</string>
     <string name="MainPage">Emplea.do</string>
     <string name="HomePageSearchBarHint">Busca empleo aquí</string>
     <string name="SearchPageSearchBarHint">Busca una dirección aquí</string>
     <string name="SearchActivityTitle">Filtrar búsqueda</string>
-
     <string name="contentNotFound">La búsqueda no tuvo resultados</string>
     <string name="contentNotFoundSubtitle">Intenta más tarde</string>
 </resources>


### PR DESCRIPTION
Removes extra ApplicationName entry from the Strings.xml file, fixing #376. 

The duplicate entry with the key ApplicationName was making the app to be named as 'Android.'

<img width="349" alt="screen shot 2016-03-31 at 2 03 01 am" src="https://cloud.githubusercontent.com/assets/5662780/14166871/04e7a550-f6e5-11e5-8e3f-724572fc3eef.png">

Now the app is named correctly as Emplea.do

<img width="350" alt="screen shot 2016-03-31 at 2 07 28 am" src="https://cloud.githubusercontent.com/assets/5662780/14166926/706fa85e-f6e5-11e5-8f09-e01adf977faa.png">
