### PR TITLE
Order job opportunities by popularity level.

### DIFF
--- a/EmpleoDotNet.Repository/JobOpportunityRepository.cs
+++ b/EmpleoDotNet.Repository/JobOpportunityRepository.cs
@@ -84,7 +84,9 @@ namespace EmpleoDotNet.Repository
                 .Include(x => x.JobOpportunityLocation)
                 .Include(x => x.JobOpportunityLikes);
 
-            jobs = jobs.OrderByDescending(x => x.Id);
+            jobs = jobs
+                .OrderByDescending(x => x.JobOpportunityLikes.Count(l => l.Like))
+                .ThenByDescending(x => x.Id);
             
             //Filter by JobCategory
             if ((parameter.JobCategory != JobCategory.All && parameter.JobCategory != JobCategory.Invalid))
@@ -158,6 +160,7 @@ namespace EmpleoDotNet.Repository
         public List<JobOpportunity> GetLatestJobOpportunity(int quantity)
         {
             return GetAll().OrderByDescending(m => m.PublishedDate)
+                .ThenByDescending(x => x.JobOpportunityLikes.Count(c => c.Like))
                 .Include(m => m.JobOpportunityLocation)
                 .Include(x => x.JobOpportunityLikes)
                 .Take(quantity)


### PR DESCRIPTION
## What's new?

Job opportunities are ordered now by popularity level.

* At home screen job opportunities first are ordered by publish date (because the purpose of this screen is to see the latest job opportunities) and then by upvotes count.
* At job opportunities screen first are ordered by up votes count and then by Id.

Related issues: #379, #308 