### PR TITLE
Introduce a global way to get APIs key easily

### DIFF
--- a/Mobile/Android/Android.csproj
+++ b/Mobile/Android/Android.csproj
@@ -140,7 +140,6 @@
     <Compile Include="MainPage\PagerAdapter.cs" />
     <Compile Include="SearchPage\SearchActivity.cs" />
     <Compile Include="Services\BitmapResizer.cs" />
-    <Compile Include="EmpleadoApp.cs" />
     <Compile Include="ViewModel\MainViewModel.cs" />
     <Compile Include="ViewModel\ViewModelLocator.cs" />
     <Compile Include="Framework\Bootstrapping\Bootstrapping.cs" />
@@ -190,6 +189,8 @@
     <Compile Include="About\ContributorAddedEventHandler.cs" />
     <Compile Include="Services\EmailService.cs" />
     <Compile Include="Services\KeyboardService.cs" />
+    <Compile Include="Services\AssetReader.cs" />
+    <Compile Include="EmpleadoApp.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />
@@ -320,5 +321,8 @@
       <Project>{B9BC593D-5A47-4153-8102-02E112360FEE}</Project>
       <Name>APIs</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidAsset Include="Assets\MobileConfig.json" />
   </ItemGroup>
 </Project>

--- a/Mobile/Android/Assets/MobileConfig.json
+++ b/Mobile/Android/Assets/MobileConfig.json
@@ -1,0 +1,5 @@
+{
+"XamarinInsightKey":"XAMARINKEY",
+"GitHubKey":"GITHUBKEY",
+"ANY_OTHER_PROPERTY":"ANY_OTHER_REPLACE_ME"
+}

--- a/Mobile/Android/Empleado.cs
+++ b/Mobile/Android/Empleado.cs
@@ -19,10 +19,5 @@ namespace Android
 
 		public static string WHICH_USER_OPEN_APP_VERSION = "WHICH_USER_OPEN_APP_VERSION";
 	}
-
-	public class Keys
-	{
-		public static string XAMARIN_INSIGHT_KEY = "";
-	}
 }
 

--- a/Mobile/Android/EmpleadoApp.cs
+++ b/Mobile/Android/EmpleadoApp.cs
@@ -21,22 +21,7 @@ namespace Android
 			base.OnCreate ();
 
 			AppContext = this;
-
-			SetupInsight();
-		}
-
-		void SetupInsight ()
-		{
-			Insights.Initialize(Keys.XAMARIN_INSIGHT_KEY, AppContext);
-
-			Insights.HasPendingCrashReport += async(sender, isStartupCrash) =>
-			{
-				if (isStartupCrash)
-				{
-					await Insights.PurgePendingCrashReports();
-				}
-			};
-		}
+		} 
 	}
 }
 

--- a/Mobile/Android/Framework/Bootstrapping/Bootstrapping.cs
+++ b/Mobile/Android/Framework/Bootstrapping/Bootstrapping.cs
@@ -11,6 +11,8 @@ using Api.Contract;
 using Api;
 using APIs;
 using Android.Views.InputMethods;
+using Xamarin;
+using Android.Content;
 
 namespace Empleado
 {
@@ -23,6 +25,10 @@ namespace Empleado
 			Init();
 
 			RegisterViewModels();
+
+			InitXamarinInsight
+				( ServiceLocator.Current.GetInstance<IContextService>()
+				, ServiceLocator.Current.GetInstance<IMobileConfigurationManager>());
 		}
 
 		void Init ()
@@ -55,6 +61,8 @@ namespace Empleado
 			}
 			else
 			{
+				SimpleIoc.Default.Register<IAssetReader, AssetReader>();
+				SimpleIoc.Default.Register<IMobileConfigurationManager, MobileConfigurationManager>();
 				SimpleIoc.Default.Register<IJobRepository, JobRepository>();
 				SimpleIoc.Default.Register<IBitmapResizer<Bitmap>, BitmapResizer>();
 				SimpleIoc.Default.Register<IGeolocationService, GeolocationService>();
@@ -82,6 +90,19 @@ namespace Empleado
 			SimpleIoc.Default.Register<JobDetailFragmentViewModel,JobDetailFragmentViewModel>();
 			SimpleIoc.Default.Register<MainPageActivityViewModel,MainPageActivityViewModel>();
 			SimpleIoc.Default.Register<AboutViewModel,AboutViewModel>();
+		}
+
+		void InitXamarinInsight (IContextService contextService, IMobileConfigurationManager configService)
+		{
+			Insights.Initialize(configService.MobileConfigurationFile.XamarinInsightKey, ((Context)contextService.GetContext()));
+
+			Insights.HasPendingCrashReport += async(sender, isStartupCrash) =>
+			{
+				if (isStartupCrash)
+				{
+					await Insights.PurgePendingCrashReports();
+				}
+			};
 		}
 	}
 }

--- a/Mobile/Android/Properties/AndroidManifest.xml
+++ b/Mobile/Android/Properties/AndroidManifest.xml
@@ -3,7 +3,7 @@
 	<uses-sdk android:minSdkVersion="16" />
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 	<application android:icon="@drawable/person" android:label="Emplea.do">
-		<meta-data android:name="com.google.android.geo.API_KEY" android:value="" />
+		<meta-data android:name="com.google.android.geo.API_KEY" android:value="REPLACE_ME_WITH_YA_API_KEY" />
 		<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 		<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 	</application>

--- a/Mobile/Android/SearchPage/SearchActivity.cs
+++ b/Mobile/Android/SearchPage/SearchActivity.cs
@@ -87,7 +87,7 @@ namespace Android
 		{
 			_autocompleteFragment = (PlaceAutocompleteFragment)
 				FragmentManager.FindFragmentById(Resource.Id.place_autocomplete_fragment);
-
+			
 			_searchLayout = FindViewById<ViewGroup>(Resource.Id.MainSearchViewParent);
 
 			_toolBar = FindViewById<V7Toolbar>(Resource.Id.MainToolbar);

--- a/Mobile/Android/Services/AssetReader.cs
+++ b/Mobile/Android/Services/AssetReader.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading.Tasks;
+using System.IO;
+using Android;
+using Android.Content;
+
+namespace Core
+{
+	public class AssetReader : IAssetReader
+	{
+		Context _context;
+
+		public AssetReader (IContextService contextService)
+		{
+			_context = (Context) contextService.GetContext();
+		}
+
+		public string ReadFileAsString(string fileName)
+		{
+			if(string.IsNullOrEmpty(fileName))
+				throw new ArgumentNullException("fileName");
+
+			string content = null;
+
+			using (var sr = new StreamReader (_context.Assets.Open (fileName)))
+			{
+				content = sr.ReadToEnd ();
+			}
+
+			return content;
+		}
+	}
+}

--- a/Mobile/Core/Core.csproj
+++ b/Mobile/Core/Core.csproj
@@ -51,6 +51,11 @@
     <Compile Include="Github\OctocatContributorService.cs" />
     <Compile Include="Services\IEmailService.cs" />
     <Compile Include="IKeyboardService.cs" />
+    <Compile Include="IAssetReader.cs" />
+    <Compile Include="MobileConfig.cs" />
+    <Compile Include="CrossPlatformStuff.cs" />
+    <Compile Include="IMobileConfigurationManager.cs" />
+    <Compile Include="MobileConfigurationManager.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>
@@ -76,6 +81,9 @@
     </Reference>
     <Reference Include="Octokit">
       <HintPath>..\packages\Octokit.0.19.0\lib\portable-net45+wp80+win+wpa81\Octokit.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\portable-net45+wp80+win8+wpa81+dnxcore50\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/Mobile/Core/CrossPlatformStuff.cs
+++ b/Mobile/Core/CrossPlatformStuff.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Core
+{
+	public class Keys
+	{
+		public static string MobileConfigFileName = "MobileConfig.json";
+	}
+}
+

--- a/Mobile/Core/Github/OctocatContributorService.cs
+++ b/Mobile/Core/Github/OctocatContributorService.cs
@@ -8,7 +8,16 @@ namespace Core
 {
 	public class OctocatContributorService : IGithubContributorService
 	{
-		readonly string API_KEY = "YOUR_GITHUB_API_KEY";
+		IMobileConfigurationManager _mobileConfigService;
+
+		readonly string API_KEY;
+
+		public OctocatContributorService (IMobileConfigurationManager mobileConfigService)
+		{
+			_mobileConfigService = mobileConfigService;
+
+			API_KEY = _mobileConfigService.MobileConfigurationFile.GitHubKey;
+		}
 
 		public async Task<List<GithubUser>> GetAllContributors (string productHeaderValue, string owner, string projectName)
 		{

--- a/Mobile/Core/IAssetReader.cs
+++ b/Mobile/Core/IAssetReader.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.IO;
+using Android;
+
+namespace Core
+{
+	public interface IAssetReader
+	{
+		string ReadFileAsString(string fileName);
+	}
+
+}
+

--- a/Mobile/Core/IMobileConfigurationManager.cs
+++ b/Mobile/Core/IMobileConfigurationManager.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Core
+{
+	public interface IMobileConfigurationManager
+	{
+		MobileConfig MobileConfigurationFile { get; set; }
+	}
+
+}

--- a/Mobile/Core/MobileConfig.cs
+++ b/Mobile/Core/MobileConfig.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Core
+{
+	public class MobileConfig
+	{
+		public string GitHubKey { get; set; }
+
+		public string XamarinInsightKey { get; set; }
+	}
+}

--- a/Mobile/Core/MobileConfigurationManager.cs
+++ b/Mobile/Core/MobileConfigurationManager.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Core
+{
+	public class MobileConfigurationManager : IMobileConfigurationManager
+	{
+		IAssetReader _assetReader;
+
+		public MobileConfig MobileConfigurationFile {
+			get;
+			set;
+		}
+
+		public MobileConfigurationManager (IAssetReader assetReader)
+		{
+			_assetReader = assetReader;
+
+			Init();
+		}
+
+		void Init ()
+		{
+			var jsonContent = _assetReader.ReadFileAsString(Keys.MobileConfigFileName);
+
+			MobileConfigurationFile = JsonConvert.DeserializeObject<MobileConfig>(jsonContent);
+		}
+	}
+}

--- a/Mobile/Core/packages.config
+++ b/Mobile/Core/packages.config
@@ -3,5 +3,6 @@
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="portable-net45+win+wp80+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="portable-net45+win+wp80+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="portable-net45+win+wp80+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="portable-net45+win+wp80+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10" />
   <package id="Octokit" version="0.19.0" targetFramework="portable-net45+win+wp80+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10" />
 </packages>


### PR DESCRIPTION
### This issue is related to #431 

# What's New

- I've been receiving feedback that the repository must be clean of any API key, and it shall be CI responsability to put them.

I included a new file called **MobileConfig.json** into the **Assets** folder, if you are going to add a new API key, just make a new property in the file

![screen shot 2016-04-15 at 15 47 47](https://cloud.githubusercontent.com/assets/5881238/14574513/c0f2e4e2-0321-11e6-924f-e5d3c334999c.png)

then go to the **MobileConfig** in **Core/MobileConfig** and add the new property so the JSON parser doesn't blow up.

![screen shot 2016-04-15 at 15 24 43](https://cloud.githubusercontent.com/assets/5881238/14573952/3413ff1e-031e-11e6-9ce0-aab1e77aba7a.png)

Then to get the API keys, all you have to do is

**ViewModel**

![screen shot 2016-04-15 at 15 27 15](https://cloud.githubusercontent.com/assets/5881238/14574018/8fbbd62a-031e-11e6-8ae8-93be862d2cae.png)

Inject **IMobileConfigService** as a dependency, and then access the **MobileConfigurationFile** and there you have it.