### PR TITLE
Minor changes to the Cache Service.

### DIFF
--- a/Mobile/Android/Android.csproj
+++ b/Mobile/Android/Android.csproj
@@ -176,7 +176,6 @@
     <Compile Include="Services\JobRepository.cs" />
     <Compile Include="Services\GeolocationService.cs" />
     <Compile Include="Services\ContextService.cs" />
-    <Compile Include="Services\AkavacheAndroidImpl.cs" />
     <Compile Include="AkavacheSqliteLinkerOverride.cs" />
     <Compile Include="Services\XMLStorage.cs" />
     <Compile Include="Services\AppInfoService.cs" />
@@ -190,6 +189,7 @@
     <Compile Include="About\ContributorAddedEventHandler.cs" />
     <Compile Include="Services\EmailService.cs" />
     <Compile Include="Services\KeyboardService.cs" />
+    <Compile Include="Services\CacheService.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/Mobile/Android/Services/CacheService.cs
+++ b/Mobile/Android/Services/CacheService.cs
@@ -16,14 +16,14 @@ namespace Android
 
 		public async Task RemoveObject(string key)
 		{
-			await BlobCache.LocalMachine.Invalidate(key);
+			await BlobCache.UserAccount.Invalidate(key);
 		}
 
 		public async Task<T> GetObject<T>(string key)
 		{
 			try
 			{
-				return await BlobCache.LocalMachine.GetObject<T>(key);
+				return await BlobCache.UserAccount.GetObject<T>(key);
 			}
 			catch (KeyNotFoundException)
 			{
@@ -31,9 +31,9 @@ namespace Android
 			}
 		}
 
-		public async Task InsertObject<T>(string key, T value)
+		public async Task InsertObject<T>(string key, T value, DateTimeOffset? expiration = default(DateTimeOffset?))
 		{
-			await BlobCache.LocalMachine.InsertObject(key, value);
+			await BlobCache.UserAccount.InsertObject(key, value, expiration);
 		}
 	}
 }

--- a/Mobile/Core/ICache.cs
+++ b/Mobile/Core/ICache.cs
@@ -7,7 +7,7 @@ namespace Core
 	{
 		Task<T> GetObject<T>(string key);
 
-		Task InsertObject<T>(string key, T value);
+		Task InsertObject<T>(string key, T value, DateTimeOffset? expiration = default(DateTimeOffset?));
 
 		Task RemoveObject(string key);
 	}


### PR DESCRIPTION
Android ICache implementation now uses UserAccount instead of LocalMachine for persistency.

Android ICache implementation now receives an optional expiration parameter when saving an object.

Solves #426