### PR TITLE
Fixes compilation on Visual Studio.

### DIFF
--- a/Mobile/Android/Android.csproj
+++ b/Mobile/Android/Android.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -18,7 +18,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
+    <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
@@ -26,6 +26,18 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <RunCodeAnalysis>false</RunCodeAnalysis>
+    <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
+    <AndroidLinkSkip />
+    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
+    <EmbedAssembliesIntoApk>False</EmbedAssembliesIntoApk>
+    <BundleAssemblies>False</BundleAssemblies>
+    <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
+    <AndroidSupportedAbis />
+    <AndroidStoreUncompressedFileExtensions />
+    <MandroidI18n />
+    <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <Debugger>Xamarin</Debugger>
+    <AndroidEnableMultiDex>False</AndroidEnableMultiDex>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -190,7 +202,7 @@
     <Compile Include="Services\KeyboardService.cs" />
     <Compile Include="Services\AssetReader.cs" />
     <Compile Include="EmpleadoApp.cs" />
-    <Compile Include="Services\CacheService.cs" /> 
+    <Compile Include="Services\CacheService.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />
@@ -275,24 +287,8 @@
   </Target>
   -->
   <ItemGroup>
-    <Folder Include="Resources\drawable\" />
-    <Folder Include="LandingPage\" />
-    <Folder Include="MainPage\" />
-    <Folder Include="Resources\drawable-hdpi\" />
-    <Folder Include="Resources\drawable-mdpi\" />
-    <Folder Include="Resources\drawable-xhdpi\" />
-    <Folder Include="Resources\drawable-xxhdpi\" />
-    <Folder Include="Resources\drawable-xxxhdpi\" />
-    <Folder Include="SearchPage\" />
-    <Folder Include="Services\" />
     <Folder Include="JobDetail\" />
     <Folder Include="Views\" />
-    <Folder Include="Framework\" />
-    <Folder Include="Framework\Bootstrapping\" />
-    <Folder Include="SplashScreen\" />
-    <Folder Include="Resources\transition\" />
-    <Folder Include="Resources\menu\" />
-    <Folder Include="About\" />
   </ItemGroup>
   <ItemGroup>
     <XamarinComponentReference Include="xamandroidsupportv7cardview">


### PR DESCRIPTION
- Removes redundant whole-folder includes from Android.csproj
- Sets JavaMaximumHeap Size to 1Gb to avoid getting an OutOfMemoryException
when building.

Fixes #439