### PR TITLE
Corrected profile page UI error.

### DIFF
--- a/EmpleoDotNet/Content/css/theme/style.css
+++ b/EmpleoDotNet/Content/css/theme/style.css
@@ -1857,6 +1857,10 @@ header {
 		.color2 {
 			background: url(../images/background.jpg);
 		}
+        
+        .page-content{
+            margin-top: 50px;
+        }
 
 		#contact div[class*="col"],
 		#prefooter div[class*="col"] {

--- a/EmpleoDotNet/Views/Account/Profile.cshtml
+++ b/EmpleoDotNet/Views/Account/Profile.cshtml
@@ -3,7 +3,7 @@
 @{
     ViewBag.Title = "Mi perfil";
 }
-<div class="container">
+<div class="container page-content">
     <section>
         <div class="container">
             <div class="row">

--- a/EmpleoDotNet/Views/Shared/_JobListPartial.cshtml
+++ b/EmpleoDotNet/Views/Shared/_JobListPartial.cshtml
@@ -54,12 +54,12 @@
                         <p>
                             <span class="text-success">
                                 <i class="fa fa-lg fa-thumbs-o-up"></i>
-                                @jobOpportunity.JobOpportunityLikes.Count(x => x.Like).FormatThousand()
+                                @(jobOpportunity.JobOpportunityLikes?.Count(x => x.Like).FormatThousand())
                             </span>
                             &nbsp;
                             <span class="text-danger">
                                 <i class="fa fa-lg fa-thumbs-o-down"></i>
-                                @jobOpportunity.JobOpportunityLikes.Count(x => !x.Like).FormatThousand()
+                                @(jobOpportunity.JobOpportunityLikes?.Count(x => !x.Like).FormatThousand())
                             </span>
                         </p>
                     </div>


### PR DESCRIPTION
Corrected UI error causing Profile page title to be hidden behind the page's header.

This address the issue #387.

![screen shot 2016-04-21 at 8 59 35 pm](https://cloud.githubusercontent.com/assets/4156062/14728658/bd300514-0804-11e6-9420-3646a9f80f31.png)
