### PR TITLE
Fix issue #453 company logo url is optional

### DIFF
--- a/EmpleoDotNet/Controllers/JobOpportunityController.cs
+++ b/EmpleoDotNet/Controllers/JobOpportunityController.cs
@@ -107,7 +107,7 @@ namespace EmpleoDotNet.Controllers
                 return View(model).WithError("Debe seleccionar una Localidad.");
             }
 
-            if (!UrlHelperExtensions.IsImageAvailable(model.CompanyLogoUrl))
+            if (!string.IsNullOrWhiteSpace(model.CompanyLogoUrl) && !UrlHelperExtensions.IsImageAvailable(model.CompanyLogoUrl))
             {
                 return View(model).WithError("La url del logo debe ser a una imagen en formato png o jpg");
             }


### PR DESCRIPTION
Company logo is optional but leaving the field empty cause the validation to fail. Validation has to be made only when url is not empty.