### PR TITLE
Let Activity handle the back button if the ViewPager does not

### DIFF
--- a/Mobile/Android/MainPage/MainPageActivity.cs
+++ b/Mobile/Android/MainPage/MainPageActivity.cs
@@ -147,9 +147,11 @@ namespace Android.Activities
 				.Commit();
 		}
 
-		public override void OnBackPressed ()
+		public override void OnBackPressed()
 		{
-			_viewPagerFragment.OnBackPressed();
+			if (!_viewPagerFragment.OnBackPressed ()) {
+				base.OnBackPressed ();
+			}
 		}
 	}
 }


### PR DESCRIPTION
When the user is in the main page of the application and is viewing the list of jobs, if they press the back button they should return to the android home.

Current behavior:
Pressing the back button does nothing.

Behavior after this change:
Pressing the back button returns to the android home.
