### PR TITLE
#537 Implement Slack Approval Notifications

### DIFF
--- a/EmpleoDotNet/App_Start/EmpleadoModule.cs
+++ b/EmpleoDotNet/App_Start/EmpleadoModule.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNet.Identity;
 using Microsoft.AspNet.Identity.EntityFramework;
 using Ninject.Modules;
 using Ninject.Web.Common;
+using EmpleoDotNet.Services.Social.Slack;
 
 namespace EmpleoDotNet.App_Start
 {
@@ -30,6 +31,7 @@ namespace EmpleoDotNet.App_Start
             Kernel.Bind<IUserProfileSocialService>().To<UserProfileSocialService>();
 
             Kernel.Bind<ITwitterService>().To<TwitterService>();
+            Kernel.Bind<ISlackService>().To<SlackService>();
 
         }
     }

--- a/EmpleoDotNet/EmpleoDotNet.csproj
+++ b/EmpleoDotNet/EmpleoDotNet.csproj
@@ -343,6 +343,8 @@
     <Compile Include="ViewModel\JobOpportunitySearchViewModel.cs" />
     <Compile Include="ViewModel\JobOpportunity\Wizard.cs" />
     <Compile Include="ViewModel\NewJobOpportunityViewModel.cs" />
+    <Compile Include="ViewModel\Slack\PayloadRequestDto.cs" />
+    <Compile Include="ViewModel\Slack\PayloadResponseDto.cs" />
     <Compile Include="ViewModel\RelatedJobDto.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/EmpleoDotNet/EmpleoDotNet.csproj
+++ b/EmpleoDotNet/EmpleoDotNet.csproj
@@ -327,6 +327,8 @@
     <Compile Include="Helpers\UrlHelperExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\RssResult.cs" />
+    <Compile Include="Services\Social\Slack\ISlackService.cs" />
+    <Compile Include="Services\Social\Slack\SlackService.cs" />
     <Compile Include="Services\Social\Twitter\ITwitterService.cs" />
     <Compile Include="Services\Social\Twitter\TwitterService.cs" />
     <Compile Include="Services\AuthenticationService.cs" />

--- a/EmpleoDotNet/Services/Social/Slack/ISlackService.cs
+++ b/EmpleoDotNet/Services/Social/Slack/ISlackService.cs
@@ -1,0 +1,11 @@
+﻿using EmpleoDotNet.Core.Domain;
+using System.Threading.Tasks;
+using System.Web.Mvc;
+
+namespace EmpleoDotNet.Services.Social.Slack
+{
+    public interface ISlackService
+    {
+        Task PostNewJobOpportunity(JobOpportunity jobOpportunity, UrlHelper urlHelper);
+    }
+}

--- a/EmpleoDotNet/Services/Social/Slack/ISlackService.cs
+++ b/EmpleoDotNet/Services/Social/Slack/ISlackService.cs
@@ -7,5 +7,6 @@ namespace EmpleoDotNet.Services.Social.Slack
     public interface ISlackService
     {
         Task PostNewJobOpportunity(JobOpportunity jobOpportunity, UrlHelper urlHelper);
+        Task PostJobOpportunityResponse(JobOpportunity jobOpportunity, UrlHelper urlHelper, string responseUrl, string userId, bool approved);
     }
 }

--- a/EmpleoDotNet/Services/Social/Slack/SlackService.cs
+++ b/EmpleoDotNet/Services/Social/Slack/SlackService.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Web;
+using System.Web.Mvc;
+using EmpleoDotNet.Core.Domain;
+using EmpleoDotNet.Helpers;
+using Newtonsoft.Json;
+
+namespace EmpleoDotNet.Services.Social.Slack
+{
+    public class SlackService : ISlackService
+    {
+        private readonly string _slackWebhookUrl;
+        public SlackService()
+        {
+            var slackWebhookEndpoint = ConfigurationManager.AppSettings["slackWebhookEndpoint"];
+            _slackWebhookUrl = "https://hooks.slack.com/services/" + slackWebhookEndpoint;
+        }
+
+        public async Task PostNewJobOpportunity(JobOpportunity jobOpportunity, UrlHelper urlHelper)
+        {
+            if (string.IsNullOrWhiteSpace(jobOpportunity?.Title) || jobOpportunity.Id <= 0)
+                return;
+
+            var descriptionLength = 124;
+            var trimmedDescription = Regex.Replace(jobOpportunity.Description, "<.*?>", String.Empty).TrimStart();
+            var limitedDescription = trimmedDescription.Length > descriptionLength
+                ? trimmedDescription.Substring(0, descriptionLength) + "..."
+                : trimmedDescription;
+
+            var action = UrlHelperExtensions.SeoUrl(jobOpportunity.Id, jobOpportunity.Title);
+            var url = urlHelper.AbsoluteUrl(action, "jobs");
+            var companyName = jobOpportunity.CompanyName;
+            var logoUrl = jobOpportunity.CompanyLogoUrl;
+            var title = jobOpportunity.Title;
+
+            await PostNotification(companyName, logoUrl, title, url, limitedDescription).ConfigureAwait(false);
+        }
+
+        private async Task PostNotification(string companyName, string companyLogoUrl, string jobTitle, string jobUrl, string jobDescription)
+        {
+            // Serialize the parameters into a JSON String that represents the message
+            var stringPayload = JsonConvert.SerializeObject(new {
+                text = "A new job posting has been created!",
+                attachments = new object[] { new {
+                    fallback = "You are unable to choose an action",
+                    author_name = companyName,
+                    title = jobTitle,
+                    title_link = jobUrl,
+                    text = jobDescription,
+                    thumb_url = companyLogoUrl,
+                    callback_id = ConfigurationManager.AppSettings["slackPostValidationKey"],
+                    color = "#3AA3E3",
+                    attachment_type = "default",
+                    actions = new object[] { new
+                    {
+                        name = "approve",
+                        text = "Approve",
+                        style = "primary",
+                        type = "button",
+                        value = "approve"
+                    }, new {
+                        name = "reject",
+                        text = "Reject",
+                        style = "default",
+                        type = "button",
+                        value = "reject"
+                    }}
+                }},
+            });
+
+            // Wrap the JSON inside a StringContent which then can be used by the HttpClient class
+            var httpContent = new StringContent(stringPayload, Encoding.UTF8, "application/json");
+
+            using (HttpClient httpClient = new HttpClient())
+            {
+                httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+                // Do the actual request and await the response
+                var httpResponse = await httpClient.PostAsync(_slackWebhookUrl, httpContent);
+            }
+        }
+    }
+}

--- a/EmpleoDotNet/ViewModel/Slack/PayloadRequestDto.cs
+++ b/EmpleoDotNet/ViewModel/Slack/PayloadRequestDto.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace EmpleoDotNet.ViewModel.Slack
+{
+    public class PayloadRequestDto
+    {
+        public string text { get; set; }
+        public bool replace_original { get; set; }
+        public IEnumerable<Attachment> attachments { get; set; }
+    }
+
+    public class Attachment
+    {
+        public string fallback { get; set; }
+        public string author_name { get; set; }
+        public string title { get; set; }
+        public string title_link { get; set; }
+        public string text { get; set; }
+        public string thumb_url { get; set; }
+        public string callback_id { get; set; }
+        public string color { get; set; }
+        public string attachment_type { get; set; }
+        public IEnumerable<AttachmentAction> actions { get; set; }
+        public IEnumerable<AttachmentField> fields { get; set; }
+    }
+
+    public class AttachmentAction
+    {
+        public string name { get; set; }
+        public string text { get; set; }
+        public string style { get; set; }
+        public string type { get; set; }
+        public string value { get; set; }
+    }
+
+    public class AttachmentField
+    {
+        public string title { get; set; }
+        public string value { get; set; }
+        public bool @short { get; set; }
+    }
+}

--- a/EmpleoDotNet/ViewModel/Slack/PayloadResponseDto.cs
+++ b/EmpleoDotNet/ViewModel/Slack/PayloadResponseDto.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace EmpleoDotNet.ViewModel.Slack
+{
+    public class PayloadResponseDto
+    {
+        public string type { get; set; }
+        public IEnumerable<Action> actions { get; set; }
+        public string callback_id { get; set; }
+        public Team team { get; set; }
+        public Channel channel { get; set; }
+        public User user { get; set; }
+        public string action_ts { get; set; }
+        public string message_ts { get; set; }
+        public string attachment_id { get; set; }
+        public string token { get; set; }
+        public PayloadRequestDto original_message { get; set; }
+        public string response_url { get; set; }
+        public string trigger_id { get; set; }
+    }
+
+    public class Action
+    {
+        public string name { get; set; }
+        public string value { get; set; }
+        public string type { get; set; }
+    }
+
+    public class Team
+    {
+        public string id { get; set; }
+        public string domain { get; set; }
+    }
+
+    public class Channel
+    {
+        public string id { get; set; }
+        public string name { get; set; }
+    }
+
+    public class User
+    {
+        public string id { get; set; }
+        public string name { get; set; }
+    }
+}


### PR DESCRIPTION
# What's new?
This PR fixes the issue of filtering spam and bots posts on new listings, by manually validating every new job post in a private Slack channel maintained by the Emplea.do staff. To achieve this, we use the Slack API [Webhooks feature](https://api.slack.com/incoming-webhooks) to put notifications on a channel every time a job is posted.

These notifications are interactive, allowing the Slack app to send back responses to Emplea.do through the `/jobs/validate` endpoint when an user clicks on the _Approve_ or _Reject_ buttons.

## Changes to Auth.config
Added the following key fields:
- slackWebhookEndpoint: contains the unique segment on the webhook url used on the Slack application
- slackVerificationToken: token used to verify that the requests are coming from the Slack app

# Screenshots
![image](https://user-images.githubusercontent.com/11365103/39388860-50f1bcc6-4a51-11e8-992b-9085f2fd346e.png)
![image](https://user-images.githubusercontent.com/11365103/39556353-ccac4084-4e4d-11e8-8e62-e76de5872334.png)

# Task List
- ~~Send the notification message to a Slack channel when a new job is posted~~
- ~~Set up an endpoint to receive the Approved/Rejected messages from Slack users~~
- ~~Document better how to set this up~~