### PR TITLE
#537 Fix error handling in Slack notifications

### DIFF
--- a/EmpleoDotNet/Services/Social/Slack/ISlackService.cs
+++ b/EmpleoDotNet/Services/Social/Slack/ISlackService.cs
@@ -8,5 +8,6 @@ namespace EmpleoDotNet.Services.Social.Slack
     {
         Task PostNewJobOpportunity(JobOpportunity jobOpportunity, UrlHelper urlHelper);
         Task PostJobOpportunityResponse(JobOpportunity jobOpportunity, UrlHelper urlHelper, string responseUrl, string userId, bool approved);
+        Task PostJobOpportunityErrorResponse(JobOpportunity jobOpportunity, UrlHelper urlHelper, string responseUrl);
     }
 }

--- a/EmpleoDotNet/Services/Social/Slack/SlackService.cs
+++ b/EmpleoDotNet/Services/Social/Slack/SlackService.cs
@@ -25,6 +25,42 @@ namespace EmpleoDotNet.Services.Social.Slack
             _slackWebhookUrl = "https://hooks.slack.com/services/" + slackWebhookEndpoint;
         }
 
+        public async Task PostJobOpportunityErrorResponse(JobOpportunity jobOpportunity, UrlHelper urlHelper, string responseUrl)
+        {
+            if (jobOpportunity == null)
+            {
+                var payloadObject = new PayloadRequestDto()
+                {
+                    text = "A new job posting has been created!",
+                    replace_original = true,
+                    attachments = new List<Attachment> { new Attachment {
+                        fallback = "Oops! Looks like this job was removed by its author.",
+                        text = "Oops! Looks like this job was removed by its author.",
+                        callback_id = "0",
+                        color = "danger",
+                        attachment_type = "default"
+                    }}
+                };
+                await PostNotification(payloadObject, responseUrl).ConfigureAwait(false);
+            } 
+            else
+            {
+                var payloadObject = new PayloadRequestDto()
+                {
+                    text = "A new job posting has been created!",
+                    replace_original = true,
+                    attachments = new List<Attachment> { new Attachment {
+                        fallback = "Oops! Looks like something went wrong with this job posting. Log in and check " + urlHelper.AbsoluteUrl("", "elmah.axd") + " for more details.",
+                        text = "Oops! Looks like something went wrong with this job posting. Log in and check " + urlHelper.AbsoluteUrl("", "elmah.axd") + " for more details.",
+                        callback_id = jobOpportunity?.Id.ToString(),
+                        color = "danger",
+                        attachment_type = "default"
+                    }}
+                };
+                await PostNotification(payloadObject, responseUrl).ConfigureAwait(false);
+            }
+        }
+
         public async Task PostJobOpportunityResponse(JobOpportunity jobOpportunity, UrlHelper urlHelper, string responseUrl, string userId, bool approved)
         {
             if (string.IsNullOrWhiteSpace(jobOpportunity?.Title) || jobOpportunity.Id <= 0)


### PR DESCRIPTION
# What has changed?
This PR improves the way errors are handled when interacting with the Slack notifications previously implemented in PR #539 . 
- If a certain post is deleted by the time someone approves or deletes the job, the notification will show a proper error message.
- Any other exception that occurs during the validation response will present a more generic error message, with a link to the Elmah dashboard to deal with the issue.

# Screenshots
![image](https://user-images.githubusercontent.com/11365103/39637696-cdba1452-4f91-11e8-871d-22d3211a241b.png)


