### PR TITLE
Adding the ability to change how many jobs are shown on the homepage

### DIFF
--- a/EmpleoDotNet/Controllers/HomeController.cs
+++ b/EmpleoDotNet/Controllers/HomeController.cs
@@ -7,6 +7,8 @@ using EmpleoDotNet.Services;
 using EmpleoDotNet.ViewModel;
 using System.Collections.Generic;
 using EmpleoDotNet.Helpers;
+using System.Configuration;
+using EmpleoDotNet.Core.Domain;
 
 namespace EmpleoDotNet.Controllers
 {
@@ -18,20 +20,26 @@ namespace EmpleoDotNet.Controllers
                 CategoriesCount = _jobOpportunityRepository.GetMainJobCategoriesCount()
             };
 
-            int howMany=7; 
-            int.TryParse(ConfigurationManager.AppSettings["HomeController:RecentJobCount"], out howMany);
-                        
-H           var model = _jobOpportunityRepository.GetLatestJobOpportunity(howMany);
-            return View(model);
+            return View(GetRecentJobs());
         }
 
         public ActionResult Rss()
         {         
-             int howMany=7; 
-            int.TryParse(ConfigurationManager.AppSettings["HomeController:RecentJobCount"], out howMany);
-
-            var model = _jobOpportunityRepository.GetLatestJobOpportunity(7);
+            var model = GetRecentJobs();
             return new RssResult(Constants.RssTitle, Constants.RssDescription, model.ToSyndicationList());
+        }
+
+        private IList<JobOpportunity> GetRecentJobs()
+        {
+            int howMany;
+            int defaultCount = 7;
+            if (int.TryParse(ConfigurationManager.AppSettings["HomeController:RecentJobCount"], out howMany))
+            {
+                defaultCount = howMany;
+            }
+
+            var model = _jobOpportunityRepository.GetLatestJobOpportunity(defaultCount);
+            return model;
         }
 
         public HomeController(IJobOpportunityRepository jobOpportunityRepository)

--- a/EmpleoDotNet/Controllers/HomeController.cs
+++ b/EmpleoDotNet/Controllers/HomeController.cs
@@ -18,12 +18,18 @@ namespace EmpleoDotNet.Controllers
                 CategoriesCount = _jobOpportunityRepository.GetMainJobCategoriesCount()
             };
 
-            var model = _jobOpportunityRepository.GetLatestJobOpportunity(7);
+            int howMany=7; 
+            int.TryParse(ConfigurationManager.AppSettings["HomeController:RecentJobCount"], out howMany);
+                        
+H           var model = _jobOpportunityRepository.GetLatestJobOpportunity(howMany);
             return View(model);
         }
 
         public ActionResult Rss()
         {         
+             int howMany=7; 
+            int.TryParse(ConfigurationManager.AppSettings["HomeController:RecentJobCount"], out howMany);
+
             var model = _jobOpportunityRepository.GetLatestJobOpportunity(7);
             return new RssResult(Constants.RssTitle, Constants.RssDescription, model.ToSyndicationList());
         }

--- a/EmpleoDotNet/Global.asax.cs
+++ b/EmpleoDotNet/Global.asax.cs
@@ -1,4 +1,5 @@
-﻿using System.Configuration;
+﻿using System;
+using System.Configuration;
 using System.Web;
 using System.Web.Mvc;
 using System.Web.Optimization;
@@ -11,9 +12,15 @@ namespace EmpleoDotNet
     {
         protected void Application_Start()
         {
-            Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.Active.InstrumentationKey =
-           ConfigurationManager.AppSettings["AppInsightsKey"];
-
+            try
+            {
+                Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.Active.InstrumentationKey =
+               ConfigurationManager.AppSettings["AppInsightsKey"];
+            }
+            catch(Exception)
+            {
+                // Oh Sh!t - No Telemetry Son!
+            }
             AreaRegistration.RegisterAllAreas();
             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
             RouteConfig.RegisterRoutes(RouteTable.Routes);


### PR DESCRIPTION
### What's New
Enables the customization of how many recent jobs show up on the home page. This is configurable via ```AppSettings```.

|Before | After|
|--|--|
|![Before](https://user-images.githubusercontent.com/2293759/67734335-270da000-f9d7-11e9-8965-abaf7b11828b.png)|![After](https://user-images.githubusercontent.com/2293759/67734334-270da000-f9d7-11e9-9fba-a9a1c39d974c.png)|


